### PR TITLE
Removed in Django 1.9 warning

### DIFF
--- a/src/shorturls/__init__.py
+++ b/src/shorturls/__init__.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.utils.importlib import import_module
+from importlib import import_module
 from shorturls import baseconv
 
 default_converter = baseconv.base62


### PR DESCRIPTION
RemovedInDjango19Warning: django.utils.importlib will be removed in Django 1.9.