### PR TITLE
updates import.

### DIFF
--- a/src/shorturls/__init__.py
+++ b/src/shorturls/__init__.py
@@ -1,6 +1,9 @@
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.utils.importlib import import_module
+try:
+    from importlib import import_module
+except:
+    from django.utils.importlib import import_module
 from shorturls import baseconv
 
 default_converter = baseconv.base62
@@ -15,5 +18,3 @@ if hasattr(settings, 'SHORTURLS_DEFAULT_CONVERTER'):
         default_converter = getattr(mod, conv_name)
     except AttributeError:
         raise ImproperlyConfigured('Could not load converter specified by SHORTURLS_DEFAULT_CONVERTER. %s is not in %s.' % (conv_name, mod))
-
-    


### PR DESCRIPTION
`Django 1.8` displays a warning that `importlib` will be removed from django.utils in `Django 1.9`.

This is a solution, from [django-compressor](https://github.com/carltongibson/django-compressor/commit/dc35047f2e9f840de55305aa16003c3e2cf71fe7).