### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/src/shorturls/__init__.py
+++ b/src/shorturls/__init__.py
@@ -13,8 +13,8 @@ if hasattr(settings, 'SHORTURLS_DEFAULT_CONVERTER'):
     try:
         mod = import_module(mod_name)
     except ImportError, e:
-        raise ImproperlyConfigured('Could not load converter specified by SHORTURLS_DEFAULT_CONVERTER. Error was: %s' % e)
+        raise ImproperlyConfigured('Could not load converter specified by SHORTURLS_DEFAULT_CONVERTER. Error was: {0!s}'.format(e))
     try:
         default_converter = getattr(mod, conv_name)
     except AttributeError:
-        raise ImproperlyConfigured('Could not load converter specified by SHORTURLS_DEFAULT_CONVERTER. %s is not in %s.' % (conv_name, mod))
+        raise ImproperlyConfigured('Could not load converter specified by SHORTURLS_DEFAULT_CONVERTER. {0!s} is not in {1!s}.'.format(conv_name, mod))

--- a/src/shorturls/templatetags/shorturl.py
+++ b/src/shorturls/templatetags/shorturl.py
@@ -10,7 +10,7 @@ class ShortURL(template.Node):
     def parse(cls, parser, token):
         parts = token.split_contents()
         if len(parts) != 2:
-            raise template.TemplateSyntaxError("%s takes exactly one argument" % parts[0])
+            raise template.TemplateSyntaxError("{0!s} takes exactly one argument".format(parts[0]))
         return cls(template.Variable(parts[1]))
         
     def __init__(self, obj):
@@ -43,14 +43,14 @@ class ShortURL(template.Node):
     def get_prefix(self, model):
         if not hasattr(self.__class__, '_prefixmap'):
             self.__class__._prefixmap = dict((m,p) for p,m in settings.SHORTEN_MODELS.items())
-        key = '%s.%s' % (model._meta.app_label, model.__class__.__name__.lower())
+        key = '{0!s}.{1!s}'.format(model._meta.app_label, model.__class__.__name__.lower())
         return self.__class__._prefixmap[key]
         
 class RevCanonical(ShortURL):
     def render(self, context):
         url = super(RevCanonical, self).render(context)
         if url:
-            return mark_safe('<link rev="canonical" href="%s">' % url)
+            return mark_safe('<link rev="canonical" href="{0!s}">'.format(url))
         else:
             return ''
 

--- a/src/shorturls/tests/models.py
+++ b/src/shorturls/tests/models.py
@@ -14,7 +14,7 @@ class Animal(models.Model):
         return self.name
         
     def get_absolute_url(self):
-        return '/animal/%s/' % self.id
+        return '/animal/{0!s}/'.format(self.id)
         
 class Vegetable(models.Model):
     name = models.CharField(max_length=100)
@@ -26,7 +26,7 @@ class Vegetable(models.Model):
         return self.name
         
     def get_absolute_url(self):
-        return 'http://example.net/veggies/%s' % self.id
+        return 'http://example.net/veggies/{0!s}'.format(self.id)
     
 class Mineral(models.Model):
     name = models.CharField(max_length=100)

--- a/src/shorturls/tests/test_views.py
+++ b/src/shorturls/tests/test_views.py
@@ -28,7 +28,7 @@ class RedirectViewTestCase(TestCase):
         """
         Test the basic operation of a working redirect.
         """
-        response = self.client.get('/A%s' % enc(12345))
+        response = self.client.get('/A{0!s}'.format(enc(12345)))
         self.assertEqual(response.status_code, 301)
         self.assertEqual(response['Location'], 'http://example.com/animal/12345/')
         
@@ -37,7 +37,7 @@ class RedirectViewTestCase(TestCase):
         Test a relative redirect when the Sites app isn't installed.
         """
         settings.SHORTEN_FULL_BASE_URL = None
-        response = self.client.get('/A%s' % enc(54321), HTTP_HOST='example.org')
+        response = self.client.get('/A{0!s}'.format(enc(54321)), HTTP_HOST='example.org')
         self.assertEqual(response.status_code, 301)
         self.assertEqual(response['Location'], 'http://example.org/animal/54321/')
         
@@ -45,7 +45,7 @@ class RedirectViewTestCase(TestCase):
         """
         Test a redirect when the object returns a complete URL.
         """
-        response = self.client.get('/V%s' % enc(785))
+        response = self.client.get('/V{0!s}'.format(enc(785)))
         self.assertEqual(response.status_code, 301)
         self.assertEqual(response['Location'], 'http://example.net/veggies/785')
         
@@ -55,7 +55,7 @@ class RedirectViewTestCase(TestCase):
         self.assertEqual(404, self.client.get('/Vssssss').status_code)
 
     def test_model_without_get_absolute_url(self):
-        self.assertEqual(404, self.client.get('/M%s' % enc(10101)).status_code)
+        self.assertEqual(404, self.client.get('/M{0!s}'.format(enc(10101))).status_code)
         
 def enc(id):
     return base62.from_decimal(id)

--- a/src/shorturls/urls.py
+++ b/src/shorturls/urls.py
@@ -3,7 +3,7 @@ from django.conf.urls import *
 
 urlpatterns = patterns('', 
     url(
-        regex = '^(?P<prefix>%s)(?P<tiny>\w+)$' % '|'.join(settings.SHORTEN_MODELS.keys()),
+        regex = '^(?P<prefix>{0!s})(?P<tiny>\w+)$'.format('|'.join(settings.SHORTEN_MODELS.keys())),
         view  = 'shorturls.views.redirect',
     ),
 )

--- a/src/shorturls/views.py
+++ b/src/shorturls/views.py
@@ -35,7 +35,7 @@ def redirect(request, prefix, tiny, converter=default_converter):
     try:
         url = obj.get_absolute_url()
     except AttributeError:
-        raise Http404("'%s' models don't have a get_absolute_url() method." % model.__name__)
+        raise Http404("'{0!s}' models don't have a get_absolute_url() method.".format(model.__name__))
     
     # We might have to translate the URL -- the badly-named get_absolute_url
     # actually returns a domain-relative URL -- into a fully qualified one.
@@ -51,10 +51,10 @@ def redirect(request, prefix, tiny, converter=default_converter):
         
     # Next, if the sites app is enabled, redirect to the current site.
     elif Site._meta.installed:
-        base = 'http://%s/' % Site.objects.get_current().domain
+        base = 'http://{0!s}/'.format(Site.objects.get_current().domain)
         
     # Finally, fall back on the current request.
     else:
-        base = 'http://%s/' % RequestSite(request).domain
+        base = 'http://{0!s}/'.format(RequestSite(request).domain)
         
     return HttpResponsePermanentRedirect(urlparse.urljoin(base, url))


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:bfirsh:django-shorturls?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:bfirsh:django-shorturls?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
