### PR TITLE
Load reverse from the new location for Django 2.x compatibility

### DIFF
--- a/src/shorturls/templatetags/shorturl.py
+++ b/src/shorturls/templatetags/shorturl.py
@@ -2,7 +2,7 @@ from six.moves.urllib.parse import urljoin
 
 from django import template
 from django.conf import settings
-from django.core import urlresolvers
+from django.urls import reverse, NoReverseMatch
 from django.utils.safestring import mark_safe
 from shorturls import default_converter as converter, views
 
@@ -37,11 +37,11 @@ class ShortURL(template.Node):
             return urljoin(settings.SHORT_BASE_URL, prefix + tinyid)
 
         try:
-            return urlresolvers.reverse(views.redirect, kwargs={
+            return reverse(views.redirect, kwargs={
                 'prefix': prefix,
                 'tiny': tinyid
             })
-        except urlresolvers.NoReverseMatch:
+        except NoReverseMatch:
             return ''
 
     def get_prefix(self, model):


### PR DESCRIPTION
The reverse function moved in Django 1.10, so this change works with all currently-supported versions of Django (currently 1.11 and 2.1 onwards). Obviously it breaks compatibility with 1.9.