### PR TITLE
Release version 3.0.0 with Python 3.10+ and Django 4.2+ support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,16 @@
 Change log
 ==========
 
+3.0.0 (2026-03-01)
+------------------
+
+- Require Python 3.10+.
+- Add support for Django 4.2 and 5.2.
+- Drop support for all Django versions older than 4.2.
+- Drop the ``six`` dependency; use stdlib and modern Django imports.
+- Replace ``setup.py`` with ``pyproject.toml``.
+- Replace Travis CI with GitHub Actions.
+
 2.0.0 (2016-12-15)
 ------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-shorturls"
-version = "2.0.0"
+version = "3.0.0"
 description = "A URL shortening app for Django."
 readme = "README.rst"
 license = "BSD-3-Clause"


### PR DESCRIPTION
## Summary
This release updates django-shorturls to version 3.0.0 with modernized Python and Django support requirements.

## Key Changes
- **Version bump**: Updated to 3.0.0
- **Python requirement**: Now requires Python 3.10+
- **Django support**: Added support for Django 4.2 and 5.2; dropped support for all versions older than 4.2
- **Dependencies**: Removed the `six` dependency in favor of stdlib and modern Django imports
- **Build system**: Migrated from `setup.py` to `pyproject.toml`
- **CI/CD**: Replaced Travis CI with GitHub Actions

## Notable Details
This is a major version bump reflecting significant modernization of the project's dependencies and tooling. The removal of the `six` compatibility library indicates a shift away from Python 2 support patterns, aligning with the Python 3.10+ requirement.

https://claude.ai/code/session_01K8vyrtXxjkaB29oNDtV3jt